### PR TITLE
feat: support multiple memory slots in calculator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::io::stdin;
 
 fn main() {
-    let mut memory: f64 = 0.0;
+    // let mut memory: f64 = 0.0;
+    let mut memories: Vec<f64> = vec![0.0; 10];
     let mut prev_result: f64 = 0.0;
     for line in stdin().lines() {
         // 1行読み取って空行なら終了
@@ -13,35 +14,39 @@ fn main() {
         let tokens: Vec<&str> = line.split(char::is_whitespace).collect();
 
         // memoryへの書き込み
-        if tokens[0] == "mem+" || tokens[0] == "mem-" {
-            // &mut（可変参照）を付けないと、値を変更しても実引数のmemoryは変わらない
-            // &mutを付けない場合、memoryの値が関数の仮引数にCopyされる動きとなる(f64はCopyトレイトを実装しているため)
-            // 結果、両者は別のスタック領域に格納される
-            add_and_print_memory(&mut memory, prev_result);
+        let is_memory = tokens[0].starts_with("mem");
+        if is_memory && tokens[0].ends_with('+') {
+            add_and_print_memory(&mut memories, tokens[0], prev_result);
+            continue;
+        } else if is_memory && tokens[0].ends_with('-') {
+            add_and_print_memory(&mut memories, tokens[0], -prev_result);
             continue;
         }
 
         // 式の計算
-        let left = eval_token(tokens[0], memory);
-        let right = eval_token(tokens[2], memory);
+        let left = eval_token(tokens[0], &memories);
+        let right = eval_token(tokens[2], &memories);
         let result = eval_expression(left, tokens[1], right);
         print_output(result);
         prev_result = result;
     }
 }
 
-fn add_and_print_memory(memory: &mut f64, prev_result: f64) {
-    *memory += prev_result;
-    print_output(*memory);
+fn add_and_print_memory(memories: &mut [f64], token: &str, prev_result: f64) {
+    let slot_index: usize = token[3..token.len() - 1].parse().unwrap();
+    memories[slot_index] += prev_result; // 自動的に参照外しが行われる
+                                         // (*memories)[slot_index] += prev_result; と同じ
+    print_output(memories[slot_index]);
 }
 
 fn print_output(value: f64) {
     println!(" => {}", value);
 }
 
-fn eval_token(token: &str, memory: f64) -> f64 {
-    if token == "mem" {
-        memory
+fn eval_token(token: &str, memories: &[f64]) -> f64 {
+    if token.starts_with("mem") {
+        let slot_index: usize = token[3..].parse().unwrap();
+        memories[slot_index]
     } else {
         // 参照のtoken(&str)をもとに新しいf64の値を生成して返す
         token.parse().unwrap() // 型を指定しなくていいのは、memoryがf64なので型推論されている


### PR DESCRIPTION
計算機において複数のメモリスロットをサポート。メモリスロットのベクタを導入し、特定のスロットに対する操作が可能になりました。"mem+0" や "mem-1" などのように、スロットを指定してメモリに追加・減算を行えるようにしました。