### PR TITLE
refactor: improve token handling and memory access logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,29 +11,36 @@ fn main() {
             break;
         }
         // 空行で分割
-        let tokens: Vec<&str> = line.split(char::is_whitespace).collect();
+        let tokens = Token::split(&line);
 
-        // memoryへの書き込み
-        let is_memory = tokens[0].starts_with("mem");
-        if is_memory && tokens[0].ends_with('+') {
-            memory.add_and_print(tokens[0], prev_result);
-            continue;
-        } else if is_memory && tokens[0].ends_with('-') {
-            memory.add_and_print(tokens[0], -prev_result);
-            continue;
+        // 式の検証
+        match &tokens[0] {
+            Token::MemoryPlus(memory_name) => {
+                // メモリへの加算
+                let memory_name = memory_name.to_string();
+                let result = memory.add(memory_name, prev_result);
+                print_output(result);
+            }
+            Token::MemoryMinus(memory_name) => {
+                // メモリへの減算
+                let memory_name = memory_name.to_string();
+                let result = memory.add(memory_name, -prev_result);
+                print_output(result);
+            }
+            _ => {
+                // 式の計算
+                let left = eval_token(&tokens[0], &memory);
+                let right = eval_token(&tokens[2], &memory);
+                let result = eval_expression(left, &tokens[1], right);
+                print_output(result);
+                prev_result = result;
+            }
         }
-
-        // 式の計算
-        let left = memory.eval_token(tokens[0]);
-        let right = memory.eval_token(tokens[2]);
-        let result = eval_expression(left, tokens[1], right);
-        print_output(result);
-        prev_result = result;
     }
 }
 
 struct Memory {
-    slots: HashMap<String, f64>
+    slots: HashMap<String, f64>,
 }
 
 impl Memory {
@@ -43,29 +50,73 @@ impl Memory {
         }
     }
 
-    fn add_and_print(&mut self, token: &str, prev_result: f64) {
-        let slot_name = token[3..token.len() - 1].to_string();
+    fn add(&mut self, slot_name: String, prev_result: f64) -> f64 {
         // slot_nameに対応するメモリを探す
         match self.slots.entry(slot_name) {
             Entry::Occupied(mut entry) => {
                 // メモリが見つかったので、値を書き換える
                 *entry.get_mut() += prev_result;
-                print_output(*entry.get());
+                *entry.get()
             }
             Entry::Vacant(entry) => {
                 // メモリが見つからなかったので、値を書き込む
                 entry.insert(prev_result);
-                print_output(prev_result);
+                prev_result
             }
         }
     }
 
-    fn eval_token(&self, token: &str) -> f64 {
-        if token.starts_with("mem") {
-            let slot_name = &token[3..];
-            self.slots.get(slot_name).copied().unwrap_or(0.0)
-        } else {
-            token.parse().unwrap()
+    fn get(&self, slot_name: &str) -> f64 {
+        self.slots.get(slot_name).copied().unwrap_or(0.0)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Token {
+    Number(f64),
+    MemoryRef(String),
+    MemoryPlus(String),
+    MemoryMinus(String),
+    Plus,
+    Minus,
+    Asterisk,
+    Slash,
+}
+
+impl Token {
+    fn parse(value: &str) -> Self {
+        match value {
+            "+" => Self::Plus,
+            "-" => Self::Minus,
+            "*" => Self::Asterisk,
+            "/" => Self::Slash,
+            _ if value.starts_with("mem") => {
+                let mut memory_name = value[3..].to_string();
+                if value.ends_with('+') {
+                    memory_name.pop(); // 末尾の1文字を削除
+                    Self::MemoryPlus(memory_name)
+                } else if value.ends_with('-') {
+                    memory_name.pop(); // 末尾の1文字を削除
+                    Self::MemoryMinus(memory_name)
+                } else {
+                    Self::MemoryRef(memory_name)
+                }
+            }
+            _ => Self::Number(value.parse().unwrap()),
+        }
+    }
+
+    fn split(text: &str) -> Vec<Self> {
+        text.split(char::is_whitespace).map(Self::parse).collect()
+    }
+}
+
+fn eval_token(token: &Token, memory: &Memory) -> f64 {
+    match token {
+        Token::Number(value) => *value,
+        Token::MemoryRef(memory_name) => memory.get(memory_name),
+        _ => {
+            unreachable!()
         }
     }
 }
@@ -74,12 +125,12 @@ fn print_output(value: f64) {
     println!(" => {}", value);
 }
 
-fn eval_expression(left: f64, operator: &str, right: f64) -> f64 {
+fn eval_expression(left: f64, operator: &Token, right: f64) -> f64 {
     match operator {
-        "+" => left + right,
-        "-" => left - right,
-        "*" => left * right,
-        "/" => left / right,
+        Token::Plus => left + right,
+        Token::Minus => left - right,
+        Token::Asterisk => left * right,
+        Token::Slash => left / right,
         _ => {
             // 不明な演算子
             unreachable!();


### PR DESCRIPTION
コードの可読性とメンテナンス性向上のために、トークンの解析を専用のToken列挙型に分離しました。また、メモリ操作のロジックをリファクタリングし、`add_and_print`メソッドを`add`メソッドに置き換え、出力を外部に移動しました。これにより、計算とメモリの役割が明確になりました。